### PR TITLE
Add localhost-only Spring Boot module with embedded Neo4j and capabilities/health endpoints

### DIFF
--- a/localhost-neo4j-service/README.md
+++ b/localhost-neo4j-service/README.md
@@ -1,0 +1,42 @@
+# localhost-neo4j-service
+
+Spring Boot application that:
+
+- Accepts only localhost connections.
+- Does not require endpoint authentication.
+- Exposes:
+  - `GET /capabilities`
+  - `GET /health`
+- Starts an embedded Neo4j server at startup.
+- Publishes Neo4j Bolt URL through `/capabilities`.
+- Uses a Neo4j plugin drop-in directory (`var/neo4j/plugins`).
+- Closes Neo4j cleanly at shutdown.
+
+## Run
+
+```bash
+./mvnw -pl localhost-neo4j-service spring-boot:run
+```
+
+## Build
+
+```bash
+./mvnw -pl localhost-neo4j-service clean package
+```
+
+## IntelliJ IDEA
+
+1. Open the repository root as a Maven project.
+2. Import module `localhost-neo4j-service`.
+3. Run `LocalhostNeo4jApplication`.
+
+## Configuration
+
+All runtime options are in `src/main/resources/application.yml` and can be overridden via environment variables or external YAML.
+
+Key properties are under:
+
+- `server.*` for HTTP bind address/port.
+- `app.security.allowed-hosts` for allowed caller addresses.
+- `app.neo4j.*` for embedded Neo4j host/ports/directories.
+- `app.neo4j.config.*` to pass arbitrary Neo4j settings.

--- a/localhost-neo4j-service/pom.xml
+++ b/localhost-neo4j-service/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.integratedmodelling</groupId>
+        <artifactId>klab-services</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>localhost-neo4j-service</artifactId>
+    <name>localhost-neo4j-service</name>
+    <description>Spring Boot service exposing capabilities and health with embedded Neo4j</description>
+
+    <properties>
+        <neo4j.version>5.26.5</neo4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.test</groupId>
+            <artifactId>neo4j-harness</artifactId>
+            <version>${neo4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/LocalhostNeo4jApplication.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/LocalhostNeo4jApplication.java
@@ -1,0 +1,14 @@
+package org.example.localhostneo4j;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class LocalhostNeo4jApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LocalhostNeo4jApplication.class, args);
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/AppSecurityProperties.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/AppSecurityProperties.java
@@ -1,0 +1,12 @@
+package org.example.localhostneo4j.config;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Validated
+@ConfigurationProperties(prefix = "app.security")
+public record AppSecurityProperties(@NotEmpty List<String> allowedHosts) {
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/Neo4jServerProperties.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/Neo4jServerProperties.java
@@ -1,0 +1,78 @@
+package org.example.localhostneo4j.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Validated
+@ConfigurationProperties(prefix = "app.neo4j")
+public class Neo4jServerProperties {
+
+    @NotBlank
+    private String host = "127.0.0.1";
+
+    private int boltPort = 7687;
+
+    private int httpPort = 7474;
+
+    @NotNull
+    private Path dataDirectory = Path.of("./var/neo4j/data");
+
+    @NotNull
+    private Path pluginsDirectory = Path.of("./var/neo4j/plugins");
+
+    private Map<String, String> config = new LinkedHashMap<>();
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getBoltPort() {
+        return boltPort;
+    }
+
+    public void setBoltPort(int boltPort) {
+        this.boltPort = boltPort;
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public void setHttpPort(int httpPort) {
+        this.httpPort = httpPort;
+    }
+
+    public Path getDataDirectory() {
+        return dataDirectory;
+    }
+
+    public void setDataDirectory(Path dataDirectory) {
+        this.dataDirectory = dataDirectory;
+    }
+
+    public Path getPluginsDirectory() {
+        return pluginsDirectory;
+    }
+
+    public void setPluginsDirectory(Path pluginsDirectory) {
+        this.pluginsDirectory = pluginsDirectory;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/SecurityConfig.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package org.example.localhostneo4j.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http, AppSecurityProperties securityProperties) throws Exception {
+        Set<String> allowedHosts = Set.copyOf(securityProperties.allowedHosts());
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .addFilterBefore(new LocalhostOnlyFilter(allowedHosts), BasicAuthenticationFilter.class)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+
+        return http.build();
+    }
+
+    private static final class LocalhostOnlyFilter extends OncePerRequestFilter {
+
+        private final Set<String> allowedHosts;
+
+        private LocalhostOnlyFilter(Set<String> allowedHosts) {
+            this.allowedHosts = allowedHosts;
+        }
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        FilterChain filterChain) throws ServletException, IOException {
+            String remoteHost = request.getRemoteAddr();
+            if (!allowedHosts.contains(remoteHost)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Only localhost connections are allowed");
+                return;
+            }
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/neo4j/EmbeddedNeo4jManager.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/neo4j/EmbeddedNeo4jManager.java
@@ -1,0 +1,59 @@
+package org.example.localhostneo4j.neo4j;
+
+import org.example.localhostneo4j.config.Neo4jServerProperties;
+import org.neo4j.harness.Neo4j;
+import org.neo4j.harness.Neo4jBuilders;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+
+@Component
+public class EmbeddedNeo4jManager {
+
+    private final Neo4jServerProperties properties;
+    private final Neo4j neo4j;
+
+    public EmbeddedNeo4jManager(Neo4jServerProperties properties) throws IOException {
+        this.properties = properties;
+
+        Files.createDirectories(properties.getDataDirectory());
+        Files.createDirectories(properties.getPluginsDirectory());
+
+        var builder = Neo4jBuilders.newInProcessBuilder()
+                .withConfig("server.directories.data", properties.getDataDirectory().toAbsolutePath().toString())
+                .withConfig("server.directories.plugins", properties.getPluginsDirectory().toAbsolutePath().toString())
+                .withConfig("dbms.security.auth_enabled", "false")
+                .withConfig("server.default_listen_address", properties.getHost())
+                .withConfig("server.default_advertised_address", properties.getHost())
+                .withConfig("server.bolt.listen_address", properties.getHost() + ":" + properties.getBoltPort())
+                .withConfig("server.http.listen_address", properties.getHost() + ":" + properties.getHttpPort());
+
+        for (Map.Entry<String, String> entry : properties.getConfig().entrySet()) {
+            builder = builder.withConfig(entry.getKey(), entry.getValue());
+        }
+
+        this.neo4j = builder.build();
+    }
+
+    public String boltUri() {
+        return neo4j.boltURI().toString();
+    }
+
+    public String httpUri() {
+        return neo4j.httpURI().toString();
+    }
+
+    public String pluginsDirectory() {
+        return properties.getPluginsDirectory().toAbsolutePath().toString();
+    }
+
+    public String dataDirectory() {
+        return properties.getDataDirectory().toAbsolutePath().toString();
+    }
+
+    public void shutdown() {
+        neo4j.close();
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/neo4j/Neo4jLifecycle.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/neo4j/Neo4jLifecycle.java
@@ -1,0 +1,19 @@
+package org.example.localhostneo4j.neo4j;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Neo4jLifecycle {
+
+    private final EmbeddedNeo4jManager neo4jManager;
+
+    public Neo4jLifecycle(EmbeddedNeo4jManager neo4jManager) {
+        this.neo4jManager = neo4jManager;
+    }
+
+    @PreDestroy
+    public void close() {
+        neo4jManager.shutdown();
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/web/CapabilitiesController.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/web/CapabilitiesController.java
@@ -1,0 +1,30 @@
+package org.example.localhostneo4j.web;
+
+import org.example.localhostneo4j.neo4j.EmbeddedNeo4jManager;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class CapabilitiesController {
+
+    private final EmbeddedNeo4jManager neo4jManager;
+
+    public CapabilitiesController(EmbeddedNeo4jManager neo4jManager) {
+        this.neo4jManager = neo4jManager;
+    }
+
+    @GetMapping("/capabilities")
+    public Map<String, Object> capabilities() {
+        return Map.of(
+                "service", "localhost-neo4j-service",
+                "neo4j", Map.of(
+                        "boltUrl", neo4jManager.boltUri(),
+                        "httpUrl", neo4jManager.httpUri(),
+                        "pluginsDirectory", neo4jManager.pluginsDirectory(),
+                        "dataDirectory", neo4jManager.dataDirectory()
+                )
+        );
+    }
+}

--- a/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/web/HealthController.java
+++ b/localhost-neo4j-service/src/main/java/org/example/localhostneo4j/web/HealthController.java
@@ -1,0 +1,19 @@
+package org.example.localhostneo4j.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "UP",
+                "timestamp", Instant.now().toString()
+        );
+    }
+}

--- a/localhost-neo4j-service/src/main/resources/application.yml
+++ b/localhost-neo4j-service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  address: 127.0.0.1
+  port: 8080
+
+app:
+  security:
+    allowed-hosts:
+      - 127.0.0.1
+      - 0:0:0:0:0:0:0:1
+      - ::1
+  neo4j:
+    host: 127.0.0.1
+    bolt-port: 7687
+    http-port: 7474
+    data-directory: ./var/neo4j/data
+    plugins-directory: ./var/neo4j/plugins
+    config:
+      server.directories.logs: ./var/neo4j/logs
+      dbms.logs.query.enabled: VERBOSE
+      dbms.security.procedures.unrestricted: '*'

--- a/localhost-neo4j-service/src/test/java/org/example/localhostneo4j/LocalhostNeo4jApplicationTests.java
+++ b/localhost-neo4j-service/src/test/java/org/example/localhostneo4j/LocalhostNeo4jApplicationTests.java
@@ -1,0 +1,49 @@
+package org.example.localhostneo4j;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LocalhostNeo4jApplicationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpointIsUp() throws Exception {
+        mockMvc.perform(get("/health").with(request -> {
+                    request.setRemoteAddr("127.0.0.1");
+                    return request;
+                }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void capabilitiesExposesBoltUrl() throws Exception {
+        mockMvc.perform(get("/capabilities").with(request -> {
+                    request.setRemoteAddr("127.0.0.1");
+                    return request;
+                }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.neo4j.boltUrl", containsString("bolt://")));
+    }
+
+    @Test
+    void nonLocalhostCallIsRejected() throws Exception {
+        mockMvc.perform(get("/health").with(request -> {
+                    request.setRemoteAddr("10.1.2.3");
+                    return request;
+                }))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>klab.cli</module>
         <module>klab.modeler</module>
         <module>klab.distribution</module>
+        <module>localhost-neo4j-service</module>
         <!--        <module>klab.lsp</module>-->
     </modules>
 


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained Spring Boot service that only accepts connections from localhost, does not require endpoint authentication, and exposes a simple capability and health surface.
- Start an embedded Neo4j instance at application startup, surface its Bolt/HTTP endpoint and directories via the capabilities endpoint, and allow runtime configuration (including a plugins drop-in directory) through YAML.
- Ensure the embedded database is properly closed at shutdown and make the module easy to import into IntelliJ or publish on GitHub as part of the multi-module project.

### Description
- Added a new Maven module `localhost-neo4j-service` and registered it in the root reactor `pom.xml` so it can be imported as part of the repository as a standard Maven module.
- Implemented a Spring Boot entrypoint `LocalhostNeo4jApplication` with `SecurityConfig` that installs a `LocalhostOnlyFilter` driven by `app.security.allowed-hosts` and configures Spring Security so endpoints are `permitAll` but only accessible from allowed caller IPs.
- Implemented `EmbeddedNeo4jManager` which starts an embedded Neo4j instance via Neo4j Harness using settings from `Neo4jServerProperties`, creates `data` and `plugins` directories, applies arbitrary `app.neo4j.config.*` entries, and exposes `boltUri()`/`httpUri()`; added `Neo4jLifecycle` to close the instance on shutdown.
- Added `GET /capabilities` (returns service info and Neo4j bolt/http URLs and directories) and `GET /health` endpoints, a default `application.yml` with `server` + `app.neo4j` and `app.security` defaults, a README, and integration tests `LocalhostNeo4jApplicationTests` using `MockMvc` to validate health, capabilities, and rejection of non-localhost requests.

### Testing
- The module includes automated tests (`LocalhostNeo4jApplicationTests`) that exercise `/health`, `/capabilities`, and the localhost-only filter and are designed to run with `mvn -pl localhost-neo4j-service test` or via IntelliJ; these tests are present but were not executed successfully in CI here.
- Attempted `./mvnw -pl localhost-neo4j-service test` failed because the Maven wrapper main class/installer JAR is missing in this repository (wrapper not present).
- Attempts to run `mvn -pl localhost-neo4j-service test` and `mvn -f localhost-neo4j-service/pom.xml test` failed due to repository/plugin resolution issues external to this module (HTTP 403 errors / unresolved plugin metadata), so the included tests could not be run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a154e9443883279893cae8bd410420)